### PR TITLE
Add default config enter & build permissions

### DIFF
--- a/src/main/java/io/github/lama06/schneckenhaus/SchneckenhausPlugin.java
+++ b/src/main/java/io/github/lama06/schneckenhaus/SchneckenhausPlugin.java
@@ -11,9 +11,9 @@ import io.github.lama06.schneckenhaus.shell.ShellManager;
 import io.github.lama06.schneckenhaus.shell.custom.CustomShell;
 import io.github.lama06.schneckenhaus.systems.Systems;
 import io.papermc.paper.plugin.lifecycle.event.types.LifecycleEvents;
-import org.bstats.bukkit.Metrics;
+/*import org.bstats.bukkit.Metrics;
 import org.bstats.charts.SimplePie;
-import org.bstats.charts.SingleLineChart;
+import org.bstats.charts.SingleLineChart;*/
 import org.bukkit.Bukkit;
 import org.bukkit.event.Listener;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -74,11 +74,11 @@ public final class SchneckenhausPlugin extends JavaPlugin implements Listener {
             command = new SchneckenhausCommand();
             getLifecycleManager().registerEventHandler(LifecycleEvents.COMMANDS, event -> command.register(event.registrar()));
 
-            try {
+            /*try {
                 startBstats();
             } catch (Exception e) {
                 getSLF4JLogger().warn("Failed to start bStats", e);
-            }
+            }*/
 
             Bukkit.getPluginManager().registerEvents(this, this);
 
@@ -89,7 +89,7 @@ public final class SchneckenhausPlugin extends JavaPlugin implements Listener {
         }
     }
 
-    private void startBstats() {
+    /*private void startBstats() {
         Metrics metrics = new Metrics(this, BSTATS_ID);
         metrics.addCustomChart(new SimplePie("custom_shell_types", () -> getPluginConfig().getCustom().isEmpty() ? "no" : "yes"));
         metrics.addCustomChart(new SingleLineChart("shells", shellManager::getCurrentShellCount));
@@ -101,7 +101,7 @@ public final class SchneckenhausPlugin extends JavaPlugin implements Listener {
             return language.getName();
         }));
         metrics.addCustomChart(new SimplePie("world_count", () -> String.valueOf(config.getConfig().getWorlds().size())));
-    }
+    }*/
 
     @Override
     public Logger getSLF4JLogger() {

--- a/src/main/java/io/github/lama06/schneckenhaus/config/SchneckenhausConfig.java
+++ b/src/main/java/io/github/lama06/schneckenhaus/config/SchneckenhausConfig.java
@@ -4,6 +4,7 @@ import io.github.lama06.schneckenhaus.SchneckenhausPlugin;
 import io.github.lama06.schneckenhaus.shell.chest.ChestShellConfig;
 import io.github.lama06.schneckenhaus.shell.custom.CustomShellConfig;
 import io.github.lama06.schneckenhaus.shell.head.HeadShellConfig;
+import io.github.lama06.schneckenhaus.shell.permission.ShellPermissionMode;
 import io.github.lama06.schneckenhaus.shell.shulker.ShulkerShellConfig;
 import org.bukkit.DyeColor;
 import org.bukkit.Location;
@@ -34,6 +35,9 @@ public final class SchneckenhausConfig {
     private final ConditionalTaskFeatureConfig escapePrevention = new ConditionalTaskFeatureConfig(60);
     private final ConditionalTaskFeatureConfig repairSystem = new ConditionalTaskFeatureConfig(200);
     private Location fallbackExitLocation;
+
+    private ShellPermissionMode defaultEnterPermissionMode = ShellPermissionMode.EVERYBODY;
+    private ShellPermissionMode defaultBuildPermissionMode = ShellPermissionMode.EVERYBODY;
 
     public SchneckenhausConfig() {
         worlds.put("schneckenhaus", new WorldConfig(true));
@@ -118,6 +122,18 @@ public final class SchneckenhausConfig {
         if (config.get("fallback_exit_location") instanceof Map<?, ?> fallbackExitLocation) {
             this.fallbackExitLocation = ConfigUtil.deserializeLocation(fallbackExitLocation);
         }
+
+        if (config.get("default_enter_permission_mode") instanceof String enterModeStr) {
+            try {
+                defaultEnterPermissionMode = ShellPermissionMode.valueOf(enterModeStr.toUpperCase(Locale.ROOT));
+            } catch (IllegalArgumentException ignored) { }
+        }
+
+        if (config.get("default_build_permission_mode") instanceof String buildModeStr) {
+            try {
+                defaultBuildPermissionMode = ShellPermissionMode.valueOf(buildModeStr.toUpperCase(Locale.ROOT));
+            } catch (IllegalArgumentException ignored) { }
+        }
     }
 
     public Map<String, Object> serialize() {
@@ -148,6 +164,9 @@ public final class SchneckenhausConfig {
         config.put("escape_prevention", escapePrevention.serialize());
         config.put("repair_system", repairSystem.serialize());
         config.put("fallback_exit_location", ConfigUtil.serializeLocation(fallbackExitLocation, true));
+
+        config.put("default_enter_permission_mode", defaultEnterPermissionMode.name());
+        config.put("default_build_permission_mode", defaultBuildPermissionMode.name());
 
         config.put("data_version", SchneckenhausPlugin.INSTANCE.getPluginMeta().getVersion());
 
@@ -205,4 +224,13 @@ public final class SchneckenhausConfig {
     public Location getFallbackExitLocation() {
         return fallbackExitLocation;
     }
+
+    public ShellPermissionMode getDefaultEnterPermissionMode() {
+        return defaultEnterPermissionMode;
+    }
+
+    public ShellPermissionMode getDefaultBuildPermissionMode() {
+        return defaultBuildPermissionMode;
+    }
+
 }

--- a/src/main/java/io/github/lama06/schneckenhaus/shell/ShellBuilder.java
+++ b/src/main/java/io/github/lama06/schneckenhaus/shell/ShellBuilder.java
@@ -125,12 +125,19 @@ public abstract class ShellBuilder extends ConstantsHolder implements ShellData 
             owner = creator;
         }
 
-        if (enterPermissionMode == null) {
+        /*if (enterPermissionMode == null) {
             enterPermissionMode = ShellPermissionMode.EVERYBODY;
         }
 
         if (buildPermissionMode == null) {
             buildPermissionMode = ShellPermissionMode.EVERYBODY;
+        }*/
+        if (enterPermissionMode == null) {
+            enterPermissionMode = plugin.getPluginConfig().getDefaultEnterPermissionMode();
+        }
+
+        if (buildPermissionMode == null) {
+            buildPermissionMode = plugin.getPluginConfig().getDefaultBuildPermissionMode();
         }
 
         String insertSql = """

--- a/src/main/java/io/github/lama06/schneckenhaus/shell/ShellBuilder.java
+++ b/src/main/java/io/github/lama06/schneckenhaus/shell/ShellBuilder.java
@@ -125,13 +125,6 @@ public abstract class ShellBuilder extends ConstantsHolder implements ShellData 
             owner = creator;
         }
 
-        /*if (enterPermissionMode == null) {
-            enterPermissionMode = ShellPermissionMode.EVERYBODY;
-        }
-
-        if (buildPermissionMode == null) {
-            buildPermissionMode = ShellPermissionMode.EVERYBODY;
-        }*/
         if (enterPermissionMode == null) {
             enterPermissionMode = plugin.getPluginConfig().getDefaultEnterPermissionMode();
         }


### PR DESCRIPTION
- added option to set default permission for building inside of shell, to prevent having hardcoded "Everyone" permission which for newbie players and new players to this system could lead to potential damage of their shells after creation or later if they don't know how to manage it at first
- added option to set default permission for entering the shell itself, to prevent having hardcoded "Everyone" permission which for newbie players and new players to this system could lead to potential damage of their shells after creation or later if they don't know how to manage it at first

To be able to test/compile this on Leaf 1.21.8, I needed to comment out some code related ot bstats.
This is the error i am having if i keep bstats code:
```
[17:12:17] [Server thread/ERROR]: [ModernPluginLoadingStrategy] Could not load plugin 'schneckenhaus-3.0.1.jar' in folder 'plugins/.paper-remapped'
org.bukkit.plugin.InvalidPluginException: java.lang.NoClassDefFoundError: org/bstats/charts/CustomChart
	at io.papermc.paper.plugin.provider.type.spigot.SpigotPluginProvider.createInstance(SpigotPluginProvider.java:129) ~[leaf-1.21.8.jar:1.21.8-140-c3b9ad3]
	at io.papermc.paper.plugin.provider.type.spigot.SpigotPluginProvider.createInstance(SpigotPluginProvider.java:35) ~[leaf-1.21.8.jar:1.21.8-140-c3b9ad3]
	at io.papermc.paper.plugin.entrypoint.strategy.modern.ModernPluginLoadingStrategy.loadProviders(ModernPluginLoadingStrategy.java:116) ~[leaf-1.21.8.jar:1.21.8-140-c3b9ad3]
	at io.papermc.paper.plugin.storage.SimpleProviderStorage.enter(SimpleProviderStorage.java:38) ~[leaf-1.21.8.jar:1.21.8-140-c3b9ad3]
	at io.papermc.paper.plugin.entrypoint.LaunchEntryPointHandler.enter(LaunchEntryPointHandler.java:39) ~[leaf-1.21.8.jar:1.21.8-140-c3b9ad3]
	at org.bukkit.craftbukkit.CraftServer.loadPlugins(CraftServer.java:586) ~[leaf-1.21.8.jar:1.21.8-140-c3b9ad3]
	at net.minecraft.server.dedicated.DedicatedServer.initServer(DedicatedServer.java:287) ~[leaf-1.21.8.jar:1.21.8-140-c3b9ad3]
	at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1185) ~[leaf-1.21.8.jar:1.21.8-140-c3b9ad3]
	at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:298) ~[leaf-1.21.8.jar:1.21.8-140-c3b9ad3]
	at java.base/java.lang.Thread.run(Thread.java:1583) ~[?:?]
Caused by: java.lang.NoClassDefFoundError: org/bstats/charts/CustomChart
	at java.base/java.lang.Class.forName0(Native Method) ~[?:?]
	at java.base/java.lang.Class.forName(Class.java:534) ~[?:?]
	at java.base/java.lang.Class.forName(Class.java:513) ~[?:?]
	at org.bukkit.plugin.java.PluginClassLoader.<init>(PluginClassLoader.java:79) ~[leaf-api-1.21.8-R0.1-SNAPSHOT.jar:?]
	at io.papermc.paper.plugin.provider.type.spigot.SpigotPluginProvider.createInstance(SpigotPluginProvider.java:125) ~[leaf-1.21.8.jar:1.21.8-140-c3b9ad3]
	... 9 more
Caused by: java.lang.ClassNotFoundException: org.bstats.charts.CustomChart
	at org.bukkit.plugin.java.PluginClassLoader.loadClass0(PluginClassLoader.java:205) ~[leaf-api-1.21.8-R0.1-SNAPSHOT.jar:?]
	at org.bukkit.plugin.java.PluginClassLoader.loadClass(PluginClassLoader.java:172) ~[leaf-api-1.21.8-R0.1-SNAPSHOT.jar:?]
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:526) ~[?:?]
	at java.base/java.lang.Class.forName0(Native Method) ~[?:?]
	at java.base/java.lang.Class.forName(Class.java:534) ~[?:?]
	at java.base/java.lang.Class.forName(Class.java:513) ~[?:?]
	at org.bukkit.plugin.java.PluginClassLoader.<init>(PluginClassLoader.java:79) ~[leaf-api-1.21.8-R0.1-SNAPSHOT.jar:?]
	at io.papermc.paper.plugin.provider.type.spigot.SpigotPluginProvider.createInstance(SpigotPluginProvider.java:125) ~[leaf-1.21.8.jar:1.21.8-140-c3b9ad3]
	... 9 more
```

I have sucessfully built an artifact with these additions/modifications, so I have tested this and I can confirm it works as intended and explained above.
<img width="940" height="135" alt="image" src="https://github.com/user-attachments/assets/886c22a5-c14a-4b78-9388-e00f5da5c599" />


Thank you in advance.